### PR TITLE
Kubernetes networks

### DIFF
--- a/kubernetes-networks/README.md
+++ b/kubernetes-networks/README.md
@@ -1,0 +1,71 @@
+# Выполнено ДЗ №2
+
+ - [X] Основное ДЗ
+ - [x] Задание со *
+
+## В процессе сделано:
+ - был создан deployment разворачивающий 3 контейнера и следащий за их состоянием
+ - научились обновлять приложение
+ - настроили probes для проверти работоспособности приложения
+
+## Как запустить проект:
+ - запускается minikube командой ``` minikube start --nodes 3 ```
+ - из каталога проекта, с помощью утилиты kubectl создается namespace ``` kubectl create -f namespace.yaml ```
+ - после успешного создания namrspace, разворачивается deployment подами с окружением ``` kubectl creale -f deployment.yaml ```
+
+## Как проверить работоспособность:
+ - проверить созданное пространство имен можно командой ``` kubectl get namespace | grep homework ```
+    ответом будет сообщение 
+    ```console
+    homework               Active   45h
+    ```
+
+  - проверить созданные поды ``` kubectl get all --namespace homework | grep pod ```
+    ```
+    pod/dpl-webserver-667f89bd9b-9ljmt   0/1     Pending   0          10s
+    pod/dpl-webserver-667f89bd9b-jmkwv   0/1     Pending   0          10s
+    pod/dpl-webserver-667f89bd9b-pq8c5   0/1     Pending   0          10s
+    ```
+    как видно поды создались, но не запустились. - Это связанно с тем, что у нас выставленно требование наличие у нод метки homework с значением true
+    добавим LABEL homework=true на все ноды ```kubectl label node $(kubectl get nodes | awk /mini/'{print $1}') homework=true```
+
+  - проверить созданные поды ``` kubectl get all --namespace homework | grep pod ```
+
+    в ответ вы получите вывод 
+    ``` console
+    pod/dpl-webserver-667f89bd9b-2kfbd   1/1     Running   0          2d17h
+    pod/dpl-webserver-667f89bd9b-cbxtk   1/1     Running   0          2d17h
+    pod/dpl-webserver-667f89bd9b-q252d   1/1     Running   0          2d17h
+    ```
+    статус должен измениться на запущенные.
+
+  - проверим что все запустилось 
+    получим ссылку для проверки сервиса
+    ``` console 
+    😿  service homework/svc-webserver has no node port
+    ❗  Services [homework/svc-webserver] have type "ClusterIP" not meant to be exposed, however for local development minikube allows you to access this !
+    http://127.0.0.1:53268
+    ❗  Because you are using a Docker driver on darwin, the terminal needs to be open to run it.
+    ```
+    проверим доступность ``` curl http://127.0.0.1:54587 ```    
+    ```console
+    My index html from HW 1
+    ```
+  - проверка rollingupdate
+    Изменим параметры в deployment.yaml и запустим процесс обновления.
+    ```Deployment.yaml
+    .... echo "My index html from HW 1" > /init/index.html....
+    ````
+    заменим цифру 1 на 2 и выполним команду ``` kubectl apply -f deployment.yaml ```
+    ```
+    если в процессе обновления просмотреть что происходит с подами можно увиидеть как происходит обновление 
+    при этом выключенным будет только 1 под из 3х согласно политики обновления указанной в манифесте
+    ```
+    NAMESPACE     NAME                               READY   STATUS            RESTARTS       AGE
+    homework      dpl-webserver-5d7985877f-57ppc     0/1     PodInitializing   0              2s
+    homework      dpl-webserver-5d7985877f-69kcx     1/1     Running           0              17s
+    homework      dpl-webserver-5d7985877f-bnwr2     1/1     Running           0              17s
+    ```
+
+## PR checklist:
+  - [kubernetes-controllers] Выставлен label с темой домашнего задания

--- a/kubernetes-networks/README.md
+++ b/kubernetes-networks/README.md
@@ -4,14 +4,20 @@
  - [x] Задание со *
 
 ## В процессе сделано:
- - был создан deployment разворачивающий 3 контейнера и следащий за их состоянием
- - научились обновлять приложение
- - настроили probes для проверти работоспособности приложения
+ - настроен ингресс контроллер
+ - настроен ingress сервис для перенаправления http хапросов на веб сервер
+ - изменен probes с проверки файла на проверка http запроса
 
 ## Как запустить проект:
  - запускается minikube командой ``` minikube start --nodes 3 ```
+ - включаем ingress контроллер на minikube ``` minikube addons enable ingress ```
  - из каталога проекта, с помощью утилиты kubectl создается namespace ``` kubectl create -f namespace.yaml ```
  - после успешного создания namrspace, разворачивается deployment подами с окружением ``` kubectl creale -f deployment.yaml ```
+ - создаем сервис LoadBaalnser ```kubectl creale -f service.yaml```
+ - настраиваем service для ingress controller ``` kubectl create -f ingress-controller-lb.yaml ```
+ - настройка сомого ингресс для перенаправления запросов основываясь на http URL
+ - включить тунелирование ``` minikube tunnel ```
+
 
 ## Как проверить работоспособность:
  - проверить созданное пространство имен можно командой ``` kubectl get namespace | grep homework ```
@@ -19,28 +25,15 @@
     ```console
     homework               Active   45h
     ```
-
   - проверить созданные поды ``` kubectl get all --namespace homework | grep pod ```
-    ```
-    pod/dpl-webserver-667f89bd9b-9ljmt   0/1     Pending   0          10s
-    pod/dpl-webserver-667f89bd9b-jmkwv   0/1     Pending   0          10s
-    pod/dpl-webserver-667f89bd9b-pq8c5   0/1     Pending   0          10s
-    ```
-    как видно поды создались, но не запустились. - Это связанно с тем, что у нас выставленно требование наличие у нод метки homework с значением true
-    добавим LABEL homework=true на все ноды ```kubectl label node $(kubectl get nodes | awk /mini/'{print $1}') homework=true```
-
-  - проверить созданные поды ``` kubectl get all --namespace homework | grep pod ```
-
-    в ответ вы получите вывод 
     ``` console
     pod/dpl-webserver-667f89bd9b-2kfbd   1/1     Running   0          2d17h
     pod/dpl-webserver-667f89bd9b-cbxtk   1/1     Running   0          2d17h
     pod/dpl-webserver-667f89bd9b-q252d   1/1     Running   0          2d17h
     ```
     статус должен измениться на запущенные.
-
-  - проверим что все запустилось 
-    получим ссылку для проверки сервиса
+  - проверим что запустился service  ``` minikube service svc-webserver --url -n homework ```
+    получим ссылку для проверки сервиса ``
     ``` console 
     😿  service homework/svc-webserver has no node port
     ❗  Services [homework/svc-webserver] have type "ClusterIP" not meant to be exposed, however for local development minikube allows you to access this !
@@ -49,23 +42,32 @@
     ```
     проверим доступность ``` curl http://127.0.0.1:54587 ```    
     ```console
-    My index html from HW 1
+    My index html from HW 2
     ```
-  - проверка rollingupdate
-    Изменим параметры в deployment.yaml и запустим процесс обновления.
-    ```Deployment.yaml
-    .... echo "My index html from HW 1" > /init/index.html....
-    ````
-    заменим цифру 1 на 2 и выполним команду ``` kubectl apply -f deployment.yaml ```
+  - проверим как работает ingress controller ``` kubectl get svc ingress-nginx-controller-lb -n ingress-nginx ```
     ```
-    если в процессе обновления просмотреть что происходит с подами можно увиидеть как происходит обновление 
-    при этом выключенным будет только 1 под из 3х согласно политики обновления указанной в манифесте
+    NAME                          TYPE           CLUSTER-IP     EXTERNAL-IP    PORT(S)                      AGE
+    ingress-nginx-controller-lb   LoadBalancer   10.107.57.45   10.107.57.45   80:31116/TCP,443:31061/TCP   29m
     ```
-    NAMESPACE     NAME                               READY   STATUS            RESTARTS       AGE
-    homework      dpl-webserver-5d7985877f-57ppc     0/1     PodInitializing   0              2s
-    homework      dpl-webserver-5d7985877f-69kcx     1/1     Running           0              17s
-    homework      dpl-webserver-5d7985877f-bnwr2     1/1     Running           0              17s
+  - проверка нормально созданного ingress ``` kubectl get ingress -n homework ```
+    ```
+    NAME            CLASS   HOSTS           ADDRESS        PORTS   AGE
+    ing-webserver   nginx   homework.otus   192.168.49.2   80      24m
     ```
 
+  - проверка надо прописать в hosts файл строку вида ip адресс из вывода ``` kubectl get svc ingress-nginx-controller-lb -n ingress-nginx ``` поля    external-it и имени сервиса из конфигурации  ``` kubectl get ingress -n homework -o yaml | grep host ```
+  ```
+  - host: homework.otus
+  ```
+  ``` file: ./hosts
+  10.107.57.45 homework.otus
+  ```
+  - проверяем как рабоатет 
+  curl http://homework.otus
+  curl http://homework.otus/homepage
+в обоих случаях мы увидим 
+```
+My index html from HW 2
+```
 ## PR checklist:
-  - [kubernetes-controllers] Выставлен label с темой домашнего задания
+  - [kubernetes-networks] Выставлен label с темой домашнего задания

--- a/kubernetes-networks/deployment.yaml
+++ b/kubernetes-networks/deployment.yaml
@@ -68,12 +68,21 @@ spec:
           ports:
             - containerPort: 8000
           readinessProbe:
-            exec:
-              command:
-                - cat
-                - /homework/index.html
+            # exec:
+            #   command:
+            #     - cat
+            #     - /homework/index.html
+            # initialDelaySeconds: 5
+            # periodSeconds: 5
+            httpGet:
+              path: /index.html
+              port: 8000
+              httpHeaders:
+                - name: Custom-Header
+                  value: Awesome
             initialDelaySeconds: 5
             periodSeconds: 5
+
           volumeMounts:
             - name: vol-httproot
               mountPath: "/homework"

--- a/kubernetes-networks/deployment.yaml
+++ b/kubernetes-networks/deployment.yaml
@@ -1,0 +1,97 @@
+apiVersion: v1
+kind: ConfigMap # создаем конфигурацию для использования в NGINX
+metadata:
+  name: cmap-webserver
+  namespace: homework
+  labels:
+    HW: kuber-homework
+data:
+  nginx.conf: |
+    events {}
+    http {
+      server {
+          listen 8000;
+          root /homework;
+
+          location / {
+            autoindex on;
+          }
+      }
+    }
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dpl-webserver
+  namespace: homework
+  labels:
+    HW: deployment-kuber-homework
+spec:
+  replicas: 3 # количество подов которое мы хотим запустить
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+       maxSurge: 1 # максимальное колическтво подов запущенное поверх сузествующих
+       maxUnavailable: 1 # максимальное количество подов выключенных для обновления
+  selector:
+    matchLabels:
+      name: deployment-webserver
+  template:
+    metadata:
+      labels:
+        name: deployment-webserver
+        HW: kuber-homework
+    spec:
+#      nodeSelector:
+#        homework: "true"  # указыввем требуемый Labal ноды  для размещения подов
+      volumes:
+        - name: vol-httproot
+          emptyDir: {}
+        - name: vol-nginx-config
+          configMap:
+            name: cmap-webserver
+      initContainers:
+        - name: initindex
+          image: alpine
+          volumeMounts:
+            - name: vol-httproot
+              mountPath: "/init"
+          command:
+            - /bin/sh
+            - -c
+            - |
+              echo "My index html from HW 2" > /init/index.html
+      containers:
+        - name: webserver
+          image: nginx
+          ports:
+            - containerPort: 8000
+          readinessProbe:
+            exec:
+              command:
+                - cat
+                - /homework/index.html
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          volumeMounts:
+            - name: vol-httproot
+              mountPath: "/homework"
+            - name: vol-nginx-config
+              mountPath: /etc/nginx/nginx.conf
+              subPath: nginx.conf
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - /bin/sh
+                  - -c
+                  - |
+                    rm -f /homework/index.html
+          resources:
+            requests:
+              memory: "200Mi"
+              cpu: "250m"
+            limits:
+              memory: "400Mi"
+              cpu: "500m"

--- a/kubernetes-networks/ingress-controller-lb.yaml
+++ b/kubernetes-networks/ingress-controller-lb.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ingress-nginx-controller-lb
+  namespace: homework
+spec:
+  selector:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/name: ingress-nginx
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: 80
+    - name: https
+      protocol: TCP
+      port: 443
+      targetPort: 443
+  type: LoadBalancer
+

--- a/kubernetes-networks/ingress-controller-lb.yaml
+++ b/kubernetes-networks/ingress-controller-lb.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ingress-nginx-controller-lb
-  namespace: homework
+  namespace: ingress-nginx
 spec:
   selector:
     app.kubernetes.io/component: controller
@@ -18,4 +18,3 @@ spec:
       port: 443
       targetPort: 443
   type: LoadBalancer
-

--- a/kubernetes-networks/ingress.yaml
+++ b/kubernetes-networks/ingress.yaml
@@ -3,6 +3,10 @@ kind: Ingress
 metadata:
   name: ing-webserver
   namespace: homework
+  annotations:
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/use-regex: "true"
+    nginx.ingress.kubernetes.io/rewrite-target: /
   labels:
     name: myingress
 spec:

--- a/kubernetes-networks/ingress.yaml
+++ b/kubernetes-networks/ingress.yaml
@@ -10,11 +10,18 @@ metadata:
 spec:
   ingressClassName: nginx
   rules:
-  - host: homework.mb2
+  - host: homework.otus
     http:
       paths:
         - pathType: Prefix
           path: /
+          backend:
+            service:
+              name: svc-webserver
+              port: 
+                number: 80
+        - pathType: ImplementationSpecific
+          path: /homepage
           backend:
             service:
               name: svc-webserver

--- a/kubernetes-networks/ingress.yaml
+++ b/kubernetes-networks/ingress.yaml
@@ -1,0 +1,19 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ing-webserver
+  namespace: homework
+  labels:
+    name: myingress
+spec:
+  rules:
+  - host: homework.mb2
+    http:
+      paths:
+      - pathType: Prefix
+        path: "/"
+        backend:
+          service:
+            name: svc-webserver
+            port: 
+              number: 80

--- a/kubernetes-networks/ingress.yaml
+++ b/kubernetes-networks/ingress.yaml
@@ -4,20 +4,19 @@ metadata:
   name: ing-webserver
   namespace: homework
   annotations:
-    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
     nginx.ingress.kubernetes.io/use-regex: "true"
     nginx.ingress.kubernetes.io/rewrite-target: /
-  labels:
-    name: myingress
 spec:
+  ingressClassName: nginx
   rules:
   - host: homework.mb2
     http:
       paths:
-      - pathType: Prefix
-        path: "/"
-        backend:
-          service:
-            name: svc-webserver
-            port: 
-              number: 80
+        - pathType: Prefix
+          path: /
+          backend:
+            service:
+              name: svc-webserver
+              port: 
+                number: 80

--- a/kubernetes-networks/namespace.yaml
+++ b/kubernetes-networks/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: homework

--- a/kubernetes-networks/service.yaml
+++ b/kubernetes-networks/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: svc-webserver
+  namespace: homework
+  labels:
+    HW: kuber-homework
+spec:
+  type: ClusterIP
+  selector:
+    HW: kuber-homework
+  ports:
+    - protocol: TCP
+      targetPort: 8000
+      port: 80


### PR DESCRIPTION
# Выполнено ДЗ №4

 - [X] Основное ДЗ
 - [x] Задание со *

## В процессе сделано:
 - настроен ингресс контроллер
 - настроен ingress сервис для перенаправления http хапросов на веб сервер
 - изменен probes с проверки файла на проверка http запроса

## Как запустить проект:
 - запускается minikube командой ``` minikube start --nodes 3 ```
 - включаем ingress контроллер на minikube ``` minikube addons enable ingress ```
 - из каталога проекта, с помощью утилиты kubectl создается namespace ``` kubectl create -f namespace.yaml ```
 - после успешного создания namrspace, разворачивается deployment подами с окружением ``` kubectl creale -f deployment.yaml ```
 - создаем сервис LoadBaalnser ```kubectl creale -f service.yaml```
 - настраиваем service для ingress controller ``` kubectl create -f ingress-controller-lb.yaml ```
 - настройка сомого ингресс для перенаправления запросов основываясь на http URL
 - включить тунелирование ``` minikube tunnel ```


## Как проверить работоспособность:
 - проверить созданное пространство имен можно командой ``` kubectl get namespace | grep homework ```
    ответом будет сообщение 
    ```console
    homework               Active   45h
    ```
  - проверить созданные поды ``` kubectl get all --namespace homework | grep pod ```
    ``` console
    pod/dpl-webserver-667f89bd9b-2kfbd   1/1     Running   0          2d17h
    pod/dpl-webserver-667f89bd9b-cbxtk   1/1     Running   0          2d17h
    pod/dpl-webserver-667f89bd9b-q252d   1/1     Running   0          2d17h
    ```
    статус должен измениться на запущенные.
  - проверим что запустился service  ``` minikube service svc-webserver --url -n homework ```
    получим ссылку для проверки сервиса ``
    ``` console 
    😿  service homework/svc-webserver has no node port
    ❗  Services [homework/svc-webserver] have type "ClusterIP" not meant to be exposed, however for local development minikube allows you to access this !
    http://127.0.0.1:53268
    ❗  Because you are using a Docker driver on darwin, the terminal needs to be open to run it.
    ```
    проверим доступность ``` curl http://127.0.0.1:54587 ```    
    ```console
    My index html from HW 2
    ```
  - проверим как работает ingress controller ``` kubectl get svc ingress-nginx-controller-lb -n ingress-nginx ```
    ```
    NAME                          TYPE           CLUSTER-IP     EXTERNAL-IP    PORT(S)                      AGE
    ingress-nginx-controller-lb   LoadBalancer   10.107.57.45   10.107.57.45   80:31116/TCP,443:31061/TCP   29m
    ```
  - проверка нормально созданного ingress ``` kubectl get ingress -n homework ```
    ```
    NAME            CLASS   HOSTS           ADDRESS        PORTS   AGE
    ing-webserver   nginx   homework.otus   192.168.49.2   80      24m
    ```

  - проверка надо прописать в hosts файл строку вида ip адресс из вывода ``` kubectl get svc ingress-nginx-controller-lb -n ingress-nginx ``` поля    external-it и имени сервиса из конфигурации  ``` kubectl get ingress -n homework -o yaml | grep host ```
  ```
  - host: homework.otus
  ```
  ``` file: ./hosts
  10.107.57.45 homework.otus
  ```
  - проверяем как рабоатет 
  curl http://homework.otus
  curl http://homework.otus/homepage
в обоих случаях мы увидим 
```
My index html from HW 2
```
## PR checklist:
  - [kubernetes-networks] Выставлен label с темой домашнего задания
